### PR TITLE
feat: mobile FAB menu (bottom-right)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,7 +16,7 @@ export function Header() {
           <a href="#experience" style={{ color: '#415E72' }}>Experience</a>
           <a href="#contact" style={{ color: '#415E72' }}>Contact</a>
         </nav>
-        <button id="menuBtn" className="mobile-menu rounded-md border px-3 py-1.5 text-sm" style={{ borderColor: 'var(--nav)', color: '#415E72' }} onClick={() => {
+        <button id="menuBtn" className="mobile-menu text-sm" onClick={() => {
           const panel = document.getElementById('mobilePanel');
           if (panel) panel.style.display = panel.style.display === 'flex' ? 'none' : 'flex'
         }}>Menu</button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,7 +20,10 @@ export function Header() {
           const panel = document.getElementById('mobilePanel');
           if (panel) panel.style.display = panel.style.display === 'flex' ? 'none' : 'flex'
         }} aria-label="Open menu">
-          <span style={{ display: 'inline-block', width: '22px', height: '2px', background: 'black', borderRadius: '2px', boxShadow: '0 6px 0 0 black, 0 -6px 0 0 black' }} />
+          <span style={{ position: 'relative', display: 'inline-block', width: '22px', height: '2px', background: 'black', borderRadius: '2px' }}>
+            <span style={{ position: 'absolute', left: 0, right: 0, top: '-6px', height: '2px', background: 'black', borderRadius: '2px' }} />
+            <span style={{ position: 'absolute', left: 0, right: 0, bottom: '-6px', height: '2px', background: 'black', borderRadius: '2px' }} />
+          </span>
         </button>
       </header>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,9 @@ export function Header() {
         <button id="menuBtn" className="mobile-menu text-sm" onClick={() => {
           const panel = document.getElementById('mobilePanel');
           if (panel) panel.style.display = panel.style.display === 'flex' ? 'none' : 'flex'
-        }}>Menu</button>
+        }} aria-label="Open menu">
+          <span style={{ display: 'inline-block', width: '22px', height: '2px', background: 'black', borderRadius: '2px', boxShadow: '0 6px 0 0 black, 0 -6px 0 0 black' }} />
+        </button>
       </header>
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,7 @@ body { font-family: 'Urbanist', ui-sans-serif, system-ui; }
 @media (max-width: 640px) {
   .brand { font-size: 1.125rem; max-width: 60%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .nav-links { display: none; }
-  .mobile-menu { display: block; position: fixed; right: 16px; bottom: 16px; z-index: 70; background: var(--nav); color: black !important; border: none; box-shadow: 0 8px 20px rgba(0,0,0,.18); border-radius: 9999px; padding: 12px 16px; }
+  .mobile-menu { display: block; position: fixed; right: 16px; bottom: 16px; z-index: 70; background: var(--nav); color: black !important; border: none; box-shadow: 0 8px 20px rgba(0,0,0,.18); border-radius: 9999px; width: 56px; height: 56px; padding: 0; display: grid; place-items: center; }
   .mobile-panel { position: fixed; right: 16px; bottom: 72px; background: var(--bg1); border: 1px solid rgba(0,0,0,.08); padding: 12px 16px; display: flex; gap: 12px; flex-direction: column; z-index: 60; border-radius: 12px; box-shadow: 0 8px 20px rgba(0,0,0,.18); }
   .mobile-panel a { color: #415E72; font-size: 16px; padding: 8px 4px; }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -9,8 +9,8 @@ body { font-family: 'Urbanist', ui-sans-serif, system-ui; }
 @media (max-width: 640px) {
   .brand { font-size: 1.125rem; max-width: 60%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .nav-links { display: none; }
-  .mobile-menu { display: block; }
-  .mobile-panel { position: fixed; top: 56px; right: 0; left: 0; background: var(--bg1); border-top: 1px solid rgba(0,0,0,.08); padding: 12px 16px; display: flex; gap: 12px; flex-direction: column; z-index: 60; }
+  .mobile-menu { display: block; position: fixed; right: 16px; bottom: 16px; z-index: 70; background: var(--nav); color: black !important; border: none; box-shadow: 0 8px 20px rgba(0,0,0,.18); border-radius: 9999px; padding: 12px 16px; }
+  .mobile-panel { position: fixed; right: 16px; bottom: 72px; background: var(--bg1); border: 1px solid rgba(0,0,0,.08); padding: 12px 16px; display: flex; gap: 12px; flex-direction: column; z-index: 60; border-radius: 12px; box-shadow: 0 8px 20px rgba(0,0,0,.18); }
   .mobile-panel a { color: #415E72; font-size: 16px; padding: 8px 4px; }
 }
 .nav-retro a { color: #17313E; text-decoration: none; position: relative; }


### PR DESCRIPTION
## Summary
- Mobile menu now appears as a floating button (bottom-right) with a popover panel
- Keeps desktop header unchanged